### PR TITLE
0.3.2

### DIFF
--- a/chargax/chargax.py
+++ b/chargax/chargax.py
@@ -370,10 +370,21 @@ class Chargax(jym.Environment):
         )
 
         cars_leaving = self.get_cars_departing(key, ports)
-        cars_leaving = (
-            cars_leaving * ports.charger_is_car_connected
+        cars_leaving = (cars_leaving * ports.charger_is_car_connected).astype(
+            bool
         )  # Only consider connected cars for leaving
 
+        state = self.set_customer_satisfaction_values(state, ports, cars_leaving)
+
+        ports = ports.replace(
+            charger_is_car_connected=ports.charger_is_car_connected * ~cars_leaving,
+        )
+
+        return state, ports
+
+    def set_customer_satisfaction_values(
+        self, state: EnvState, ports: EVSE, cars_leaving: Array
+    ) -> EnvState:
         uncharged_percentages = (
             cars_leaving * jnp.maximum(ports.car_battery_desired_remaining, 0)
         ).sum()
@@ -386,23 +397,16 @@ class Chargax(jym.Environment):
             .astype(int)
         )  # Use previous time till leave to calculate overtime
         charged_undertime = (
-            (cars_leaving * jnp.maximum(0, new_time_till_leave)).sum().astype(int)
+            (cars_leaving * jnp.maximum(0, ports.car_time_till_leave)).sum().astype(int)
         )
         num_cars_leaving = cars_leaving.sum()
-
-        ports = ports.replace(
-            charger_is_car_connected=ports.charger_is_car_connected * ~cars_leaving,
-        )
-
-        state = state._replace(
+        return state._replace(
             uncharged_percentages=state.uncharged_percentages + uncharged_percentages,
             uncharged_kw=state.uncharged_kw + uncharged_kw,
             charged_overtime=state.charged_overtime + charged_overtime,
             charged_undertime=state.charged_undertime + charged_undertime,
             left_customers=state.left_customers + num_cars_leaving,
         )
-
-        return state, ports
 
     def add_new_cars(
         self, key: PRNGKeyArray, state: EnvState, ports: EVSE

--- a/chargax/chargax.py
+++ b/chargax/chargax.py
@@ -55,7 +55,7 @@ class EnvState(jym.EnvState):
     charged_overtime: int = 0
     charged_undertime: int = 0
     rejected_customers: int = 0
-    left_customers: int = 0
+    served_customers: int = 0
     exceeded_capacity: float = 0.0
     total_charged_kw: float = 0.0
     total_discharged_kw: float = 0.0
@@ -405,7 +405,7 @@ class Chargax(jym.Environment):
             uncharged_kw=state.uncharged_kw + uncharged_kw,
             charged_overtime=state.charged_overtime + charged_overtime,
             charged_undertime=state.charged_undertime + charged_undertime,
-            left_customers=state.left_customers + num_cars_leaving,
+            served_customers=state.served_customers + num_cars_leaving,
         )
 
     def add_new_cars(

--- a/chargax/chargax.py
+++ b/chargax/chargax.py
@@ -370,6 +370,9 @@ class Chargax(jym.Environment):
         )
 
         cars_leaving = self.get_cars_departing(key, ports)
+        cars_leaving = (
+            cars_leaving * ports.charger_is_car_connected
+        )  # Only consider connected cars for leaving
 
         uncharged_percentages = (
             cars_leaving * jnp.maximum(ports.car_battery_desired_remaining, 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chargax"
-version = "0.3.1"
+version = "0.3.2"
 description = "A JAX Accelerated EV Charging Simulator"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
- force leaving customers to only be True for connected chargers
- Seperate customer satisfaction fn
- rename `left_customers` to `served_customers` in EnvState